### PR TITLE
README: Use SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,7 @@ You can use multiple keys to send notifications, to do it just do this changes i
 
 ## Status
 
-#### Build Status [![Build Status](https://secure.travis-ci.org/NicosKaralis/pushmeup.png?branch=master)](http://travis-ci.org/NicosKaralis/pushmeup) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/NicosKaralis/pushmeup)
-
-#### Dependency Status [![Dependency Status](https://gemnasium.com/NicosKaralis/pushmeup.png?travis)](https://gemnasium.com/NicosKaralis/pushmeup)
+#### Build Status [![Build Status](https://secure.travis-ci.org/NicosKaralis/pushmeup.svg?branch=master)](http://travis-ci.org/NicosKaralis/pushmeup) [![Code Climate](https://codeclimate.com/badge.svg)](https://codeclimate.com/github/NicosKaralis/pushmeup)
 
 ## Contributing
 


### PR DESCRIPTION
This PR changes the build badges to SVG for sharper readability ✨

  - Drop Gemnasium badge, service closed